### PR TITLE
Invert `cell != nil` typo when checking if it was dequeued

### DIFF
--- a/content/table-data-sources.md
+++ b/content/table-data-sources.md
@@ -21,7 +21,7 @@ Pretty simple, we just check if we can dequeue a cell and make a new one if not.
 
 {{% prism swift %}}var cell: UITableViewCell? = tableView.dequeueReusableCellWithIdentifier("cell") as? UITableViewCell
 
-if cell != nil {
+if cell == nil {
 	cell = UITableViewCell(style: UITableViewCellStyle.Default, reuseIdentifier: "cell")
 }
 


### PR DESCRIPTION
Noticed a small typo in the Swift version of this example. Probably accidental, but `cell` should be nil (i.e. not dequeued) if it's going to be assigned a new cell.
