### PR TITLE
Convert cell to implicitly unwrapped optional

### DIFF
--- a/content/table-data-sources.md
+++ b/content/table-data-sources.md
@@ -19,13 +19,13 @@ cell.textLabel.text = @"A cell";{{% /prism %}}
 
 Pretty simple, we just check if we can dequeue a cell and make a new one if not. We do the same thing in Swift but we have to deal with a few unusual concepts:
 
-{{% prism swift %}}var cell: UITableViewCell? = tableView.dequeueReusableCellWithIdentifier("cell") as? UITableViewCell
+{{% prism swift %}}var cell: UITableViewCell! = tableView.dequeueReusableCellWithIdentifier("cell") as? UITableViewCell
 
 if cell == nil {
 	cell = UITableViewCell(style: UITableViewCellStyle.Default, reuseIdentifier: "cell")
 }
 
-cell!.textLabel.text = "A cell"{{% /prism %}}
-First, the potentially dequeued cell might be `nil` so we're already dealing with an optional. Moreover, the dequeued cell might be some `UITableViewCell` subclass so it's actually returned as `AnyObject?` and we downcast it to the class we know it is. The incantation for downcasting an optional is that `as?` we used, a combination of new concepts if you're coming straight from Objective-C and potentially the source of confusion here.
+cell.textLabel.text = "A cell"{{% /prism %}}
+First, the potentially dequeued cell might be `nil` so we're already dealing with an optional. Moreover, the dequeued cell might be some `UITableViewCell` subclass so it's actually returned as `AnyObject?` and we downcast it to the class we know it is. The incantation for downcasting an optional is that `as?` we used, a combination of new concepts if you're coming straight from Objective-C and potentially the source of confusion here. Since we're going to immediately provide a value for `cell` if it comes back as `nil`, we can declare it as an implicitly unwrapped optional for easier use later on.
 
 This highlights a big point for people coming from Objective-C to Swift, and one I'll restate often: the APIs really haven't changed and you can use them just about as you did before, but the finer points of Swift takes some getting used to. As long as you understand the reasons why optionals and constructs like `AnyObject` exist in Swift you shouldn't have too much trouble.


### PR DESCRIPTION
Added a little explanation about why in the post, but essentially if we're immediately checking `cell` against `nil`, there's no harm in declaring it as implicitly unwrapped -- it even makes sense, since implicitly unwrapped optionals are optionals that you're basically promising won't be `nil`. I especially like it this way better since then we aren't using `!` over and over in the code below, training ourselves out of aversion to the force-unwrapping operator.
